### PR TITLE
Add Retina scaling and virtual gamepad support for iOS

### DIFF
--- a/src/gIOSAppDelegate.mm
+++ b/src/gIOSAppDelegate.mm
@@ -50,13 +50,14 @@ static bool g_IsTerminating = false;
     
     for (UITouch *touch in allTouches) {
         CGPoint point = [touch locationInView: getView()];
+        CGFloat scale = getView().contentScaleFactor;
         
         TouchInput touchinput;
         touchinput.type = correctTouchTypeForGlist(touch.type);
         touchinput.fingerid = fingerid;
         touchinput.pointerindex = 0;
-        touchinput.x = point.x;
-        touchinput.y = point.y;
+        touchinput.x = point.x * scale;
+        touchinput.y = point.y * scale;
         
         touchinputs[0] = touchinput;
         
@@ -79,13 +80,13 @@ static bool g_IsTerminating = false;
     
     for (UITouch *touch in allTouches) {
         CGPoint point = [touch locationInView: getView()];
-        
+        CGFloat scale = getView().contentScaleFactor;
         TouchInput touchinput;
         touchinput.type = correctTouchTypeForGlist(touch.type);
         touchinput.fingerid = fingerid;
         touchinput.pointerindex = 0;
-        touchinput.x = point.x;
-        touchinput.y = point.y;
+        touchinput.x = point.x * scale;
+        touchinput.y = point.y * scale;
         
         touchinputs[0] = touchinput;
         
@@ -107,13 +108,13 @@ static bool g_IsTerminating = false;
     
     for (UITouch *touch in allTouches) {
         CGPoint point = [touch locationInView: getView()];
-        
+        CGFloat scale = getView().contentScaleFactor;
         TouchInput touchinput;
         touchinput.type = correctTouchTypeForGlist(touch.type);
         touchinput.fingerid = fingerid;
         touchinput.pointerindex = 0;
-        touchinput.x = point.x;
-        touchinput.y = point.y;
+        touchinput.x = point.x * scale;
+        touchinput.y = point.y * scale;
         
         touchinputs[0] = touchinput;
         
@@ -135,13 +136,13 @@ static bool g_IsTerminating = false;
     
     for (UITouch *touch in allTouches) {
         CGPoint point = [touch locationInView: getView()];
-        
+        CGFloat scale = getView().contentScaleFactor;
         TouchInput touchinput;
         touchinput.type = correctTouchTypeForGlist(touch.type);
         touchinput.fingerid = fingerid;
         touchinput.pointerindex = 0;
-        touchinput.x = point.x;
-        touchinput.y = point.y;
+        touchinput.x = point.x * scale;
+        touchinput.y = point.y * scale;
         
         touchinputs[0] = touchinput;
         

--- a/src/gIOSInterface.cpp
+++ b/src/gIOSInterface.cpp
@@ -7,6 +7,8 @@ struct AppParameters
 {
     std::string appName;
     gBaseApp* baseApp;
+    int unitWidth;
+    int unitHeight;
     int width;
     int height;
     int windowMode;
@@ -20,22 +22,22 @@ AppParameters params{};
 
 void init(void* baseApp, const char* appName, int windowMode, int unitWidth, int unitHeight, int screenScaling, int width, int height, bool isResizable)
 {
-    params = AppParameters{std::string(appName), (gBaseApp*)baseApp, width, height, windowMode, screenScaling, isResizable, G_LOOPMODE_NORMAL};
+    params = AppParameters{std::string(appName), (gBaseApp*)baseApp, unitWidth, unitHeight, width, height, windowMode, screenScaling, isResizable, G_LOOPMODE_NORMAL};
 }
 void setup()
 {
     ViewBounds bounds = getViewBounds();
     int unitwidth = static_cast<int>(bounds.width);
     int unitheight = static_cast<int>(bounds.height);
-    appmanager = new gAppManager(params.appName, params.baseApp, params.width, params.height, params.windowMode, unitwidth, unitheight, params.screenScaling, params.isResizable, params.loopmode);
+    appmanager = new gAppManager(params.appName, params.baseApp, unitwidth, unitheight, params.windowMode, params.unitWidth, params.unitHeight, params.screenScaling, params.isResizable, params.loopmode);
     
     appmanager->initialize();
     appmanager->setup();
+    appmanager->loop();
 }
 
 void loop()
 {
-    appmanager->loop();
     appmanager->iosLoop();
 }
 

--- a/src/gIOSViewController.mm
+++ b/src/gIOSViewController.mm
@@ -27,10 +27,13 @@ static ViewBounds viewBounds = {0, 0};
     
     view.context = m_Context;
     self.delegate = self;
+    self.preferredFramesPerSecond = 60;
+    self.paused = NO;
+    view.enableSetNeedsDisplay = NO;
     
     [EAGLContext setCurrentContext:view.context];
-    
-    viewBounds = {static_cast<float>(view.bounds.size.width), static_cast<float>(view.bounds.size.height)};
+    CGFloat scale = view.contentScaleFactor;
+    viewBounds = {static_cast<float>(view.bounds.size.width * scale), static_cast<float>(view.bounds.size.height * scale)};
     
     mainView = view;
 }
@@ -54,7 +57,7 @@ static ViewBounds viewBounds = {0, 0};
         
         fbo_initialized = true;
     }
-    
+    glViewport(0, 0, (GLsizei)view.drawableWidth, (GLsizei)view.drawableHeight);
     loop();
 }
 

--- a/src/gIOSWindow.cpp
+++ b/src/gIOSWindow.cpp
@@ -13,9 +13,11 @@
 
 gIOSWindow* window = nullptr;
 
-gIOSWindow::gIOSWindow() {
+gIOSWindow::gIOSWindow() : virtualgamepadconnected(false) {
     vsync = true;
     window = this;
+    virtualgamepadaxes.fill(0.0f);
+    virtualgamepadbuttons.fill(false);
 }
 
 gIOSWindow::~gIOSWindow() {
@@ -23,7 +25,8 @@ gIOSWindow::~gIOSWindow() {
 
 void gIOSWindow::initialize(int width, int height, int windowMode, bool isResizable)
 {
-    gBaseWindow::initialize(width, height, windowmode, isResizable);
+    gBaseWindow::initialize(width, height, windowMode, isResizable);
+    setVirtualGamepadConnected(gBaseWindow::VIRTUAL_GAMEPAD_ID, true);
 }
 
 bool gIOSWindow::getShouldClose()
@@ -34,4 +37,120 @@ bool gIOSWindow::getShouldClose()
 gIOSWindow* gIOSWindow::getWindow()
 {
     return window;
+}
+
+bool gIOSWindow::isJoystickPresent(int joystickId) {
+    return joystickId == gBaseWindow::VIRTUAL_GAMEPAD_ID &&
+           virtualgamepadconnected;
+}
+
+const float* gIOSWindow::getJoystickAxes(
+    int joystickId,
+    int* axisCountPtr
+) {
+    if(axisCountPtr) {
+        *axisCountPtr = 0;
+    }
+
+    if(joystickId != gBaseWindow::VIRTUAL_GAMEPAD_ID ||
+       !virtualgamepadconnected) {
+        return nullptr;
+    }
+
+    if(axisCountPtr) {
+        *axisCountPtr = VIRTUAL_AXIS_COUNT;
+    }
+
+    return virtualgamepadaxes.data();
+}
+
+bool gIOSWindow::isGamepadButtonPressed(
+    int joystickId,
+    int buttonId
+) {
+    if(joystickId != gBaseWindow::VIRTUAL_GAMEPAD_ID ||
+       !virtualgamepadconnected) {
+        return false;
+    }
+
+    if(buttonId < 0 ||
+       buttonId >= VIRTUAL_BUTTON_COUNT) {
+        return false;
+    }
+
+    return virtualgamepadbuttons[buttonId];
+}
+
+void gIOSWindow::setVirtualGamepadConnected(
+    int gamepadId,
+    bool connected
+) {
+    if(gamepadId != gBaseWindow::VIRTUAL_GAMEPAD_ID) {
+        return;
+    }
+
+    if(virtualgamepadconnected == connected) {
+        return;
+    }
+
+    virtualgamepadconnected = connected;
+
+    if(!connected) {
+        virtualgamepadaxes.fill(0.0f);
+        virtualgamepadbuttons.fill(false);
+
+        gJoystickDisconnectEvent event{gamepadId};
+        callEvent(event);
+        return;
+    }
+
+    gJoystickConnectEvent event{
+        gamepadId,
+        true
+    };
+
+    callEvent(event);
+}
+
+void gIOSWindow::setVirtualGamepadAxis(
+    int gamepadId,
+    int axisId,
+    float value
+) {
+    if(gamepadId != gBaseWindow::VIRTUAL_GAMEPAD_ID ||
+       !virtualgamepadconnected) {
+        return;
+    }
+
+    if(axisId < 0 ||
+       axisId >= VIRTUAL_AXIS_COUNT) {
+        return;
+    }
+
+    if(value < -1.0f) {
+        value = -1.0f;
+    }
+    else if(value > 1.0f) {
+        value = 1.0f;
+    }
+
+    virtualgamepadaxes[axisId] = value;
+}
+
+void gIOSWindow::setVirtualGamepadButton(
+    int gamepadId,
+    int buttonId,
+    bool pressed
+) {
+    if(gamepadId != gBaseWindow::VIRTUAL_GAMEPAD_ID ||
+       !virtualgamepadconnected) {
+        return;
+    }
+
+    if(buttonId < 0 ||
+       buttonId >= VIRTUAL_BUTTON_COUNT) {
+        return;
+    }
+
+    virtualgamepadbuttons[buttonId] = pressed;
 }

--- a/src/gIOSWindow.h
+++ b/src/gIOSWindow.h
@@ -9,19 +9,37 @@
 #define G_IOSWINDOW_H
 
 #include "gBaseWindow.h"
+#include <array>
 
 class gIOSWindow : public gBaseWindow {
 public:
+static constexpr int VIRTUAL_AXIS_COUNT = 6;
+static constexpr int VIRTUAL_BUTTON_COUNT = 15;
     gIOSWindow();
 	virtual ~gIOSWindow();
     
     void initialize(int width, int height, int windowMode, bool isResizable) override;
     bool getShouldClose() override;
+    bool isJoystickPresent(int joystickId) override;
+
+    bool isGamepadButtonPressed(int joystickId, int buttonId) override;
+
+    const float* getJoystickAxes(int joystickId, int* axisCountPtr) override;
+
+    void setVirtualGamepadConnected(int gamepadId, bool connected) override;
+
+    void setVirtualGamepadAxis(int gamepadId, int axisId, float value) override;
+
+    void setVirtualGamepadButton(int gamepadId, int buttonId, bool pressed) override;
     
     static gIOSWindow* getWindow();
     
     // We do not handle update and close methods here, as they are controlled
     // from the Objective-C++ part.
+private:
+    bool virtualgamepadconnected;
+    std::array<float, VIRTUAL_AXIS_COUNT> virtualgamepadaxes;
+    std::array<bool, VIRTUAL_BUTTON_COUNT> virtualgamepadbuttons;
 };
 
 void passEventToIOSWindow(int eventType);


### PR DESCRIPTION
## Summary

This PR improves the iOS platform integration and adds touchscreen gamepad support.

## Changes

- Scales touch coordinates using the view content scale factor
- Uses Retina drawable dimensions for rendering
- Configures the GLKViewController to run at 60 FPS
- Updates the OpenGL viewport using the drawable size
- Corrects the iOS application setup and loop initialization
- Fixes the window mode argument passed to the base window
- Adds a virtual gamepad implementation for touchscreen controls

## Testing

- The iOS integration was previously tested on a physical device
- Touch movement, camera look, firing and pause controls were verified
- The related Windows build completed successfully