### PR TITLE
Add Vulkan support for iOS through MoltenVK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .settings
 build
 *.DS_Store
+libs/moltenvk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,10 @@ set(IOS_PLUGIN_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 set(IOS_PLUGIN_LIBS_DIR ${IOS_PLUGIN_DIR}/libs)
 
-# MoltenVK is supplied by the application/toolchain, not vendored by this plugin.
-# Explicit cache values are preferred; VULKAN_SDK is used as a convenience fallback.
+# MoltenVK is too large to keep in the repository, so it is fetched once per
+# machine into libs/moltenvk/<version> - see the Vulkan section of the README.
+# An explicit cache value or an installed SDK in the environment wins over it, and
+# when nothing is found the engine simply builds without the Vulkan backend.
 set(GLIST_MOLTENVK_LIBRARY "" CACHE FILEPATH "Path to the matching MoltenVK library")
 set(GLIST_MOLTENVK_INCLUDE_DIR "" CACHE PATH "Directory containing vulkan/vulkan.h")
 if(IOS_PLATFORM STREQUAL "simulator")
@@ -43,18 +45,30 @@ if(IOS_PLATFORM STREQUAL "simulator")
 else()
     set(GLIST_MOLTENVK_SLICE "ios-arm64")
 endif()
+file(GLOB GLIST_MOLTENVK_BUNDLED "${IOS_PLUGIN_LIBS_DIR}/moltenvk/*")
+list(SORT GLIST_MOLTENVK_BUNDLED)
+list(REVERSE GLIST_MOLTENVK_BUNDLED)
 if(NOT GLIST_MOLTENVK_INCLUDE_DIR)
+    # find_path does nothing while the cache entry holds a value, and the empty
+    # default above is one, so the entry has to go before the search can run. The
+    # iOS toolchain restricts the find commands to the SDK, which is why these look
+    # outside the find root as well.
+    unset(GLIST_MOLTENVK_INCLUDE_DIR CACHE)
     find_path(GLIST_MOLTENVK_INCLUDE_DIR vulkan/vulkan.h
-        HINTS ENV VULKAN_SDK ENV MOLTENVK_HOME
-        PATH_SUFFIXES include MoltenVK/include)
+        HINTS ENV VULKAN_SDK ENV MOLTENVK_HOME ${GLIST_MOLTENVK_BUNDLED}
+        PATH_SUFFIXES include MoltenVK/include
+        NO_CMAKE_FIND_ROOT_PATH)
 endif()
 if(NOT GLIST_MOLTENVK_LIBRARY)
+    unset(GLIST_MOLTENVK_LIBRARY CACHE)
     find_library(GLIST_MOLTENVK_LIBRARY NAMES MoltenVK
-        HINTS ENV VULKAN_SDK ENV MOLTENVK_HOME
+        HINTS ENV VULKAN_SDK ENV MOLTENVK_HOME ${GLIST_MOLTENVK_BUNDLED}
         PATH_SUFFIXES
+            "lib/${GLIST_MOLTENVK_SLICE}"
             lib lib/MoltenVK
             "MoltenVK/MoltenVK.xcframework/${GLIST_MOLTENVK_SLICE}"
-            "MoltenVK.xcframework/${GLIST_MOLTENVK_SLICE}")
+            "MoltenVK.xcframework/${GLIST_MOLTENVK_SLICE}"
+        NO_CMAKE_FIND_ROOT_PATH)
 endif()
 if(GLIST_MOLTENVK_LIBRARY AND GLIST_MOLTENVK_INCLUDE_DIR)
     if(NOT TARGET MoltenVK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,13 +38,23 @@ set(IOS_PLUGIN_LIBS_DIR ${IOS_PLUGIN_DIR}/libs)
 # Explicit cache values are preferred; VULKAN_SDK is used as a convenience fallback.
 set(GLIST_MOLTENVK_LIBRARY "" CACHE FILEPATH "Path to the matching MoltenVK library")
 set(GLIST_MOLTENVK_INCLUDE_DIR "" CACHE PATH "Directory containing vulkan/vulkan.h")
+if(IOS_PLATFORM STREQUAL "simulator")
+    set(GLIST_MOLTENVK_SLICE "ios-arm64_x86_64-simulator")
+else()
+    set(GLIST_MOLTENVK_SLICE "ios-arm64")
+endif()
 if(NOT GLIST_MOLTENVK_INCLUDE_DIR)
     find_path(GLIST_MOLTENVK_INCLUDE_DIR vulkan/vulkan.h
-        HINTS ENV VULKAN_SDK PATH_SUFFIXES include)
+        HINTS ENV VULKAN_SDK ENV MOLTENVK_HOME
+        PATH_SUFFIXES include MoltenVK/include)
 endif()
 if(NOT GLIST_MOLTENVK_LIBRARY)
     find_library(GLIST_MOLTENVK_LIBRARY NAMES MoltenVK
-        HINTS ENV VULKAN_SDK PATH_SUFFIXES lib lib/MoltenVK)
+        HINTS ENV VULKAN_SDK ENV MOLTENVK_HOME
+        PATH_SUFFIXES
+            lib lib/MoltenVK
+            "MoltenVK/MoltenVK.xcframework/${GLIST_MOLTENVK_SLICE}"
+            "MoltenVK.xcframework/${GLIST_MOLTENVK_SLICE}")
 endif()
 if(GLIST_MOLTENVK_LIBRARY AND GLIST_MOLTENVK_INCLUDE_DIR)
     if(NOT TARGET MoltenVK)
@@ -114,6 +124,8 @@ add_apple_library(OpenGLES)
 add_apple_library(GLKit)
 add_apple_library(Metal)
 add_apple_library(QuartzCore)
+add_apple_library(CoreGraphics)
+add_apple_library(IOSurface)
 add_apple_library(AVFAudio)
 add_apple_library(AudioToolbox)
 add_apple_library(AVKit)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,9 @@ get_property(IOS_PLATFORM SOURCE ${CMAKE_TOOLCHAIN_FILE} PROPERTY PLATFORM)
 
 if(${PLATFORM} STREQUAL "OS64")
     set(IOS_PLATFORM os)
-elseif(${PLATFORM} STREQUAL "SIMULATOR64COMBINED")
+elseif(${PLATFORM} STREQUAL "SIMULATOR64COMBINED" OR
+       ${PLATFORM} STREQUAL "SIMULATORARM64" OR
+       ${PLATFORM} STREQUAL "SIMULATOR64")
     set(IOS_PLATFORM simulator)
 endif()
 
@@ -31,6 +33,32 @@ set(pluginname gipIOS)
 set(IOS_PLUGIN_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 set(IOS_PLUGIN_LIBS_DIR ${IOS_PLUGIN_DIR}/libs)
+
+# MoltenVK is supplied by the application/toolchain, not vendored by this plugin.
+# Explicit cache values are preferred; VULKAN_SDK is used as a convenience fallback.
+set(GLIST_MOLTENVK_LIBRARY "" CACHE FILEPATH "Path to the matching MoltenVK library")
+set(GLIST_MOLTENVK_INCLUDE_DIR "" CACHE PATH "Directory containing vulkan/vulkan.h")
+if(NOT GLIST_MOLTENVK_INCLUDE_DIR)
+    find_path(GLIST_MOLTENVK_INCLUDE_DIR vulkan/vulkan.h
+        HINTS ENV VULKAN_SDK PATH_SUFFIXES include)
+endif()
+if(NOT GLIST_MOLTENVK_LIBRARY)
+    find_library(GLIST_MOLTENVK_LIBRARY NAMES MoltenVK
+        HINTS ENV VULKAN_SDK PATH_SUFFIXES lib lib/MoltenVK)
+endif()
+if(GLIST_MOLTENVK_LIBRARY AND GLIST_MOLTENVK_INCLUDE_DIR)
+    if(NOT TARGET MoltenVK)
+        add_library(MoltenVK UNKNOWN IMPORTED)
+        set_target_properties(MoltenVK PROPERTIES IMPORTED_LOCATION "${GLIST_MOLTENVK_LIBRARY}")
+    endif()
+    list(APPEND IOS_PLUGIN_INCLUDES "${GLIST_MOLTENVK_INCLUDE_DIR}")
+    list(APPEND IOS_PLUGIN_LINKLIBS MoltenVK)
+    set(Lib_Vulkan MoltenVK)
+    set(GLIST_IOS_HAS_VULKAN ON)
+    message(STATUS "iOS Vulkan enabled with MoltenVK: ${GLIST_MOLTENVK_LIBRARY}")
+else()
+    message(STATUS "iOS MoltenVK not configured; Vulkan backend disabled")
+endif()
 
 ##### PLUGIN SOURCES #####
 list(APPEND IOS_PLUGIN_SRCS
@@ -84,6 +112,8 @@ add_apple_library(MobileCoreServices)
 #add_apple_library(SystemConfiguration)
 add_apple_library(OpenGLES)
 add_apple_library(GLKit)
+add_apple_library(Metal)
+add_apple_library(QuartzCore)
 add_apple_library(AVFAudio)
 add_apple_library(AudioToolbox)
 add_apple_library(AVKit)

--- a/README.md
+++ b/README.md
@@ -17,3 +17,44 @@ The plugin also ships a prebuilt host copy of the engine's `ShaderToHeader` tool
 ## Building
 
 iOS builds are driven from the app project, not from this plugin. See [GlistApp's `_apple/README.md`](https://github.com/glistengine/glistapp/blob/main/_apple/README.md) for the build, signing and troubleshooting steps.
+
+## Vulkan (MoltenVK)
+
+GlistEngine can render through Vulkan on iOS. There is no Vulkan driver on the platform, so MoltenVK translates it to Metal; this section is about getting that library in place and telling the engine to use it. Without it the plugin simply builds without the Vulkan backend, and an app asking for Vulkan falls back to OpenGL.
+
+**1. Get MoltenVK.** It is a few dozen megabytes of static archives, so it is not part of this repository and has to be fetched once per machine. Take `MoltenVK-all.tar` from the [MoltenVK releases](https://github.com/KhronosGroup/MoltenVK/releases) - the smaller `MoltenVK-ios.tar` carries only the `ios-arm64` device slice and cannot build for the simulator.
+
+**2. Put it where CMake looks**, under `libs/moltenvk/<version>`:
+
+```text
+libs/moltenvk/1.4.2/include/vulkan/vulkan.h
+libs/moltenvk/1.4.2/lib/ios-arm64/libMoltenVK.a
+libs/moltenvk/1.4.2/lib/ios-arm64_x86_64-simulator/libMoltenVK.a
+```
+
+From the extracted tarball that is `MoltenVK/MoltenVK/include` for the headers and `MoltenVK/MoltenVK/static/MoltenVK.xcframework/<slice>/libMoltenVK.a` for each library:
+
+```bash
+tar -xf MoltenVK-all.tar
+MVK=~/dev/glist/glistplugins/gipIOS/libs/moltenvk/1.4.2
+mkdir -p "$MVK/lib"
+cp -R MoltenVK/MoltenVK/include "$MVK/include"
+for slice in ios-arm64 ios-arm64_x86_64-simulator; do
+    cp -R "MoltenVK/MoltenVK/static/MoltenVK.xcframework/$slice" "$MVK/lib/$slice"
+done
+```
+
+CMake picks the slice that matches the platform being built: `ios-arm64` for a device, `ios-arm64_x86_64-simulator` for the simulator. If you already have MoltenVK elsewhere - the LunarG Vulkan SDK for macOS ships one - point at it with `VULKAN_SDK` or `MOLTENVK_HOME`, or configure with `-DGLIST_MOLTENVK_LIBRARY=` and `-DGLIST_MOLTENVK_INCLUDE_DIR=`. Those take precedence over `libs/moltenvk`.
+
+**3. Check the configure output.** It prints exactly one of these:
+
+```text
+-- iOS Vulkan enabled with MoltenVK: <path to libMoltenVK.a>
+-- iOS MoltenVK not configured; Vulkan backend disabled
+```
+
+The second line means the app is being built OpenGL-only and will stay on OpenGL no matter what it asks for at runtime.
+
+**4. Ask for the renderer** where your app passes the render engine in `main.cpp`: `G_RENDERER_VK` instead of `G_RENDERER_GL`.
+
+Two things the platform does not give you. On the simulator the swapchain only offers FIFO presentation, so the frame rate is capped at the display refresh rate and `disableVsync()` cannot lift it - use the simulator to check that a scene renders, and a device to judge cost. And there are no Vulkan validation layers on iOS; Xcode's Metal frame capture is the equivalent tool, and MoltenVK's own `MVK_CONFIG_*` environment variables turn up its logging.

--- a/src/gIOSInterface.cpp
+++ b/src/gIOSInterface.cpp
@@ -15,14 +15,23 @@ struct AppParameters
     int screenScaling;
     bool isResizable;
     int loopmode;
+    int renderEngine;
 };
 
 gAppManager* appmanager{};
 AppParameters params{};
 
-void init(void* baseApp, const char* appName, int windowMode, int unitWidth, int unitHeight, int screenScaling, int width, int height, bool isResizable)
+void init(void* baseApp, const char* appName, int windowMode, int unitWidth, int unitHeight, int screenScaling, int width, int height, bool isResizable, int renderEngine)
 {
-    params = AppParameters{std::string(appName), (gBaseApp*)baseApp, unitWidth, unitHeight, width, height, windowMode, screenScaling, isResizable, G_LOOPMODE_NORMAL};
+#ifndef GLIST_HAS_VULKAN
+    if(renderEngine == G_RENDERER_VK) renderEngine = G_RENDERER_GL;
+#endif
+    params = AppParameters{std::string(appName), (gBaseApp*)baseApp, unitWidth, unitHeight, width, height, windowMode, screenScaling, isResizable, G_LOOPMODE_NORMAL, renderEngine};
+}
+
+bool isIOSVulkanRequested()
+{
+    return params.renderEngine == G_RENDERER_VK;
 }
 void setup()
 {
@@ -30,7 +39,8 @@ void setup()
     int unitwidth = static_cast<int>(bounds.width);
     int unitheight = static_cast<int>(bounds.height);
     appmanager = new gAppManager(params.appName, params.baseApp, unitwidth, unitheight, params.windowMode, params.unitWidth, params.unitHeight, params.screenScaling, params.isResizable, params.loopmode);
-    
+    appmanager->setRenderEngine(params.renderEngine);
+
     appmanager->initialize();
     appmanager->setup();
     appmanager->loop();

--- a/src/gIOSInterface.h
+++ b/src/gIOSInterface.h
@@ -10,7 +10,7 @@
 
 #include "gIOSWindow.h"
 
-void init(void* baseApp, const char* appName, int windowMode, int unitWidth, int unitHeight, int screenScaling, int width, int height, bool isResizable);
+void init(void* baseApp, const char* appName, int windowMode, int unitWidth, int unitHeight, int screenScaling, int width, int height, bool isResizable, int renderEngine);
 void setup();
 void loop();
 void stop();
@@ -23,6 +23,8 @@ typedef struct ViewBounds
 
 // Implementation in gIOSViewController.mm
 ViewBounds getViewBounds();
+bool isIOSVulkanRequested();
+void* getIOSMetalLayer();
 
 // Implementation in gIOSAppDelegate.mm
 bool getIsTerminating();

--- a/src/gIOSMain.h
+++ b/src/gIOSMain.h
@@ -10,6 +10,6 @@
 
 #include <iosfwd>
 
-int ios_main(void* baseApp, const char* appName, int windowMode, int unitWidth, int unitHeight, int screenScaling, int width, int height, bool isResizable);
+int ios_main(void* baseApp, const char* appName, int windowMode, int unitWidth, int unitHeight, int screenScaling, int width, int height, bool isResizable, int renderEngine);
 
 #endif /* G_IOSMAIN_H */

--- a/src/gIOSMain.mm
+++ b/src/gIOSMain.mm
@@ -3,8 +3,8 @@
 #import "gIOSAppDelegate.h"
 #import "gIOSInterface.h"
 
-int ios_main(void* baseApp, const char* appName, int windowMode, int unitWidth, int unitHeight, int screenScaling, int width, int height, bool isResizable)
+int ios_main(void* baseApp, const char* appName, int windowMode, int unitWidth, int unitHeight, int screenScaling, int width, int height, bool isResizable, int renderEngine)
 {
-    init(baseApp, appName, windowMode, unitWidth, unitHeight, screenScaling, width, height, isResizable);
+    init(baseApp, appName, windowMode, unitWidth, unitHeight, screenScaling, width, height, isResizable, renderEngine);
     UIApplicationMain(0, nil, nil, NSStringFromClass([gIOSAppDelegate class]));
 }

--- a/src/gIOSViewController.h
+++ b/src/gIOSViewController.h
@@ -4,8 +4,10 @@
 {
     EAGLContext* m_Context;
     bool fbo_initialized;
+    CADisplayLink* display_link;
 }
 -(void) setupGL;
+-(void) drawVulkanFrame:(CADisplayLink*)sender;
 
 @end
 

--- a/src/gIOSViewController.mm
+++ b/src/gIOSViewController.mm
@@ -5,11 +5,13 @@
 #import <OpenGLES/EAGLDrawable.h>
 #import <OpenGLES/ES3/gl.h>
 #import <OpenGLES/EAGLIOSurface.h>
+#import <QuartzCore/CAMetalLayer.h>
 
 #import "gIOSViewController.h"
 #import "gIOSInterface.h"
 
 static UIView* mainView;
+static CAMetalLayer* mainMetalLayer;
 static ViewBounds viewBounds = {0, 0};
 
 @implementation gIOSViewController
@@ -17,6 +19,8 @@ static ViewBounds viewBounds = {0, 0};
 -(instancetype)init
 {
     self = [super init];
+    if(self) display_link = nil;
+    return self;
 }
 
 -(void) setupGL
@@ -42,9 +46,41 @@ static ViewBounds viewBounds = {0, 0};
 -(void) viewDidLoad
 {
     [super viewDidLoad];
-    [self setupGL];
+    if(isIOSVulkanRequested()) {
+        UIView* view = self.view;
+        mainMetalLayer = [CAMetalLayer layer];
+        mainMetalLayer.frame = view.bounds;
+        mainMetalLayer.contentsScale = UIScreen.mainScreen.nativeScale;
+        [view.layer addSublayer:mainMetalLayer];
+        mainView = view;
+        viewBounds = {static_cast<float>(view.bounds.size.width * mainMetalLayer.contentsScale),
+                static_cast<float>(view.bounds.size.height * mainMetalLayer.contentsScale)};
+        setup();
+        display_link = [CADisplayLink displayLinkWithTarget:self selector:@selector(drawVulkanFrame:)];
+        display_link.preferredFramesPerSecond = UIScreen.mainScreen.maximumFramesPerSecond;
+        [display_link addToRunLoop:NSRunLoop.mainRunLoop forMode:NSRunLoopCommonModes];
+    } else {
+        [self setupGL];
+        setup();
+    }
+}
 
-    setup();
+-(void) viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+    if(!mainMetalLayer) return;
+    mainMetalLayer.frame = self.view.bounds;
+    const int width = static_cast<int>(self.view.bounds.size.width * mainMetalLayer.contentsScale);
+    const int height = static_cast<int>(self.view.bounds.size.height * mainMetalLayer.contentsScale);
+    viewBounds = {static_cast<float>(width), static_cast<float>(height)};
+    gIOSWindow* window = gIOSWindow::getWindow();
+    if(window && width > 0 && height > 0) window->setSize(width, height);
+}
+
+-(void) drawVulkanFrame:(CADisplayLink*)sender
+{
+    (void)sender;
+    loop();
 }
 
 - (void) glkView:(GLKView *)view drawInRect:(CGRect)rect
@@ -71,6 +107,11 @@ static ViewBounds viewBounds = {0, 0};
 UIView* getView()
 {
     return mainView;
+}
+
+void* getIOSMetalLayer()
+{
+    return (__bridge void*)mainMetalLayer;
 }
 
 ViewBounds getViewBounds()

--- a/src/gIOSWindow.cpp
+++ b/src/gIOSWindow.cpp
@@ -11,6 +11,10 @@
 #include "gIOSWindow.h"
 #include "gIOSInterface.h"
 
+#ifdef GLIST_HAS_VULKAN
+#include <vulkan/vulkan.h>
+#endif
+
 gIOSWindow* window = nullptr;
 
 gIOSWindow::gIOSWindow() : virtualgamepadconnected(false) {
@@ -32,6 +36,42 @@ void gIOSWindow::initialize(int width, int height, int windowMode, bool isResiza
 bool gIOSWindow::getShouldClose()
 {
     return getIsTerminating();
+}
+
+bool gIOSWindow::supportsVulkan() const
+{
+#ifdef GLIST_HAS_VULKAN
+    return isIOSVulkanRequested() && getIOSMetalLayer() != nullptr;
+#else
+    return false;
+#endif
+}
+
+void gIOSWindow::getVulkanInstanceExtensions(std::vector<const char*>& extensions) const
+{
+#ifdef GLIST_HAS_VULKAN
+    extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+    extensions.push_back(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
+#else
+    (void)extensions;
+#endif
+}
+
+bool gIOSWindow::createVulkanSurface(void* instance, void* surface)
+{
+#ifdef GLIST_HAS_VULKAN
+    void* layer = getIOSMetalLayer();
+    if(layer == nullptr || instance == nullptr || surface == nullptr) return false;
+    VkMetalSurfaceCreateInfoEXT info{};
+    info.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
+    info.pLayer = layer;
+    return vkCreateMetalSurfaceEXT(*static_cast<VkInstance*>(instance), &info, nullptr,
+            static_cast<VkSurfaceKHR*>(surface)) == VK_SUCCESS;
+#else
+    (void)instance;
+    (void)surface;
+    return false;
+#endif
 }
 
 gIOSWindow* gIOSWindow::getWindow()

--- a/src/gIOSWindow.h
+++ b/src/gIOSWindow.h
@@ -31,6 +31,9 @@ static constexpr int VIRTUAL_BUTTON_COUNT = 15;
     void setVirtualGamepadAxis(int gamepadId, int axisId, float value) override;
 
     void setVirtualGamepadButton(int gamepadId, int buttonId, bool pressed) override;
+    bool supportsVulkan() const override;
+    void getVulkanInstanceExtensions(std::vector<const char*>& extensions) const override;
+    bool createVulkanSurface(void* instance, void* surface) override;
     
     static gIOSWindow* getWindow();
     


### PR DESCRIPTION
Adds the iOS half of the engine's Vulkan backend. There is no Vulkan driver on iOS, so the calls go to MoltenVK and out to Metal; this PR wires that up and documents the one manual step it needs.

Nothing changes for an existing app. When MoltenVK is not configured the plugin says so during the configure step and the engine is built without the Vulkan backend, so a `G_RENDERER_VK` request falls back to OpenGL on its own.

## What is here

**MoltenVK discovery.** MoltenVK is a few dozen megabytes of static archives, so it is not vendored here. CMake looks for an explicit `-DGLIST_MOLTENVK_LIBRARY` / `-DGLIST_MOLTENVK_INCLUDE_DIR`, then an installed SDK through `VULKAN_SDK` / `MOLTENVK_HOME`, then a copy placed under `libs/moltenvk/<version>`, picking the slice that matches `IOS_PLATFORM` - `ios-arm64` for a device, `ios-arm64_x86_64-simulator` for the simulator. It sets `GLIST_IOS_HAS_VULKAN` and `Lib_Vulkan`, which is what the engine's iOS branch keys off.

One fix worth calling out: the empty cache defaults meant `find_path` and `find_library` never ran at all - both do nothing while their cache entry already holds a value - so only an explicit `-D` ever configured Vulkan. The entries are dropped before searching now, and the search is allowed outside the find root the iOS toolchain restricts to.

**Metal surface.** The view controller creates a `CAMetalLayer` when, and only when, the app asked for Vulkan, keeps it sized with the view, and hands it to `gIOSWindow::createVulkanSurface`, which builds the surface through `VK_EXT_metal_surface`. An OpenGL app carries no Metal layer.

**Renderer selection.** The chosen render engine is carried through `init()` to the app manager, and is forced back to OpenGL when the plugin was built without Vulkan.

**README.** A Vulkan section appended to the current README: where to get MoltenVK, the layout CMake expects, how to point at an installed SDK instead, how to read the configure output, and what the simulator cannot show - it offers only FIFO presentation, so the frame rate is capped there and a device is needed to judge cost. `.gitignore` gains one line for `libs/moltenvk`, so that the copy those instructions place there cannot be committed by accident - it is tens of megabytes of static archives.

## Testing

Rebased onto current `main`. Built for the simulator in Release together with GlistEngine/GlistEngine#1275; the configure step reports the MoltenVK it picked and the Vulkan defines reach the application target. Everything outside the Vulkan path is left as it is.

## Depends on

GlistEngine/GlistEngine#1275, which declares the `gBaseWindow` hooks this implements and consumes `GLIST_IOS_HAS_VULKAN`. The two need to land together.
